### PR TITLE
If a component isn't set, mark it as coming soon on the buttons page

### DIFF
--- a/pages/components/index.tsx
+++ b/pages/components/index.tsx
@@ -85,10 +85,6 @@ export const getStaticProps: GetStaticProps = async (context) => {
 };
 
 const ComponentsPage = ({ content, menu, metadata, current, components, available, unavailable }: ComponentPageDocumentationProps) => {
-  available.map((component) => {
-    console.log(component);
-    console.log(components[component]);
-  });
   return (
     <div className="c-page">
       <Head>


### PR DESCRIPTION
The component disabling on the component index page was manual, rather than being sensitive to the component fetch from figma.  This PR changes that behavior to make component availability detect at least 1 component token set, and sort the component list into typed arrays.  Then we display those typed arrays in two sets on the page.