### PR TITLE
Bumps the version for the installer

### DIFF
--- a/installer/template/package.json
+++ b/installer/template/package.json
@@ -36,7 +36,7 @@
     },
     "homepage": "https://www.handoff.com/",
     "dependencies": {
-      "handoff-app": "^0.1.0"
+      "handoff-app": "^0.2.0"
     }
   }
   


### PR DESCRIPTION
Realized that the installer installs a package json that's one version out of date.  This fixes this, and we should make sure to incriment that on each minor release along with the change notes.