### PR TITLE
Adding effect to starter config tempalte

### DIFF
--- a/figma-exporter/src/exporters/design.ts
+++ b/figma-exporter/src/exporters/design.ts
@@ -39,7 +39,11 @@ const isArray = (input: any): input is any[] | readonly any[] => {
   return Array.isArray(input);
 };
 
-const getFileDesignTokens = async (fileId: string, accessToken: string) => {
+const getFileDesignTokens = async (fileId: string, accessToken: string): Promise<{
+  color: ColorObject[];
+  typography: TypographyObject[];
+  effect: EffectObject[];
+}> => {
   try {
     const apiResponse = await getFileStyles(fileId, accessToken);
     const file = apiResponse.data;
@@ -82,11 +86,11 @@ const getFileDesignTokens = async (fileId: string, accessToken: string) => {
             effects: document.effects
               .filter((effect) => isValidEffectType(effect.type) && effect.visible)
               .map((effect) => ({
-                  type: effect.type,
-                  value: isShadowEffectType(effect.type)
-                    ? transformFigmaEffectToCssBoxShadow(effect)
-                    : '',
-                }
+                type: effect.type,
+                value: isShadowEffectType(effect.type)
+                  ? transformFigmaEffectToCssBoxShadow(effect)
+                  : '',
+              }
               ))
           });
         } else if (isArray(document.fills) && document.fills[0] && document.fills[0].type === 'SOLID' && document.fills[0].color) {

--- a/figma-exporter/src/exporters/design.ts
+++ b/figma-exporter/src/exporters/design.ts
@@ -134,7 +134,7 @@ const getFileDesignTokens = async (fileId: string, accessToken: string) => {
     throw new Error(
       'An error occured fetching Colors and Typography.  This typically happens when the library cannot be read from Handoff'
     );
-    return { color: [], typography: [] };
+    return { color: [], typography: [], effect: [] };
   }
 };
 

--- a/installer/template/config.js
+++ b/installer/template/config.js
@@ -22,11 +22,11 @@ const config = {
     'Input Labels',
     'Link',
   ],
-  design: { color: [], typography: [] },  // Containers for holding design elements. Will be overwritten on fetch
+  design: { color: [], typography: [], effect: [] },  // Containers for holding design elements. Will be overwritten on fetch
   assets: { icons: [], logos: [] },       // Containers for holding assets. Will be overwritten on fetch
   type_copy: 'Almost before we knew it, we had left the ground.', // The sample text to use on the typography page
   color_sort: ['primary', 'secondary', 'extra', 'system'],        // The sort order of the color types
-  component_sort: ['primary', 'secondary', 'transparent'],  
+  component_sort: ['primary', 'secondary', 'transparent'],
 };
 
 module.exports = config;


### PR DESCRIPTION
We added effects to the build, but if effect: [] isn't in the config, the system throws an error.  This patch fixes that so starter projects have the proper structure.  

We should add a regression test to our pre release process to test the clean install.