### PR TITLE
Release/0.6.1

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.1] - 2023-06-28
+
+### Bugfixes
+
+- Resolves an issue with level two paths in the app not rendering right
+- Resolves an issue if the project env is set to production but the app start mode is run
+
 ## [0.6.0] - 2023-06-28
 
 0.6.0 introduces two major new tools that will make it much easier to integrate Handoff with existing projects and data pipelines. This release also reorganizes the Handoff code to make the pipeline significantly more robust, easier to extend, and easier to use in existing projects. Our goal with this release is to establish a stable Typescript API as we approach a 1.0 release.

--- a/src/app.ts
+++ b/src/app.ts
@@ -42,7 +42,7 @@ export const watchApp = async (handoff: Handoff): Promise<void> => {
     ...config.typescript,
     tsconfigPath,
   };
-  const dev = process.env.NODE_ENV !== 'production';
+  const dev = true;
   const hostname = 'localhost';
   const port = 3000;
   // when using middleware `hostname` and `port` must be provided below

--- a/src/app/pages/[level1]/[level2]/index.tsx
+++ b/src/app/pages/[level1]/[level2]/index.tsx
@@ -6,7 +6,7 @@ import CustomNav from '../../../components/SideNav/Custom';
 import { ReactMarkdown } from 'react-markdown/lib/react-markdown';
 import { MarkdownComponents } from '../../../components/Markdown/MarkdownComponents';
 import rehypeRaw from 'rehype-raw';
-import getConfig from 'next/config';
+import { getConfig } from '../../../../config';
 
 export interface SubPageType {
   params: {
@@ -39,6 +39,7 @@ export const getStaticProps: GetStaticProps = async (context) => {
   if (!level2) {
     level2 = '404';
   }
+  console.log({...fetchDocPageMarkdown(`docs/${level1}/`, reduceSlugToString(level2), `/${level1}`).props});
   return {
     props: {
       ...fetchDocPageMarkdown(`docs/${level1}/`, reduceSlugToString(level2), `/${level1}`).props,


### PR DESCRIPTION
This PR fixes two small bugs

- Resolves an issue with level two paths in the app not rendering right
- Resolves an issue if the project env is set to production but the app start mode is run

It sets the dev mode to true by default for watchApp and fixes the include path of the config loader for second level markdown pages.