### PR TITLE
Accounting for the project path when retrieving exportables in the next.js app

### DIFF
--- a/src/app/components/util/index.ts
+++ b/src/app/components/util/index.ts
@@ -342,9 +342,12 @@ export const fetchExportables = () => {
 
     const exportables = definitions
       .map((def) => {
-        const defPath = path.resolve(handoff.modulePath, 'config', 'exportables', `${def}.json`);
-
-        if (!fs.existsSync(defPath)) {
+        let defPath = path.resolve(handoff.modulePath, 'config', 'exportables', `${def}.json`);
+        const projectPath = path.resolve(path.join(handoff.workingPath, 'exportables', `${def}.json`));
+        // If the project path exists, use that first as an override
+        if (fs.existsSync(projectPath)) {
+          defPath = projectPath;
+        } else if (!fs.existsSync(defPath)) {
           return null;
         }
 


### PR DESCRIPTION
Currently we are retrieving exportables for the next.js app only from the module path. Thus causes any additional exportables to not appear in the next.js app. This update ensures that retrieving exportables takes the project path into consideration as well (just like the pipeline is already doing).