### PR TITLE
Support for figma color blending

### DIFF
--- a/dist/exporters/utils.d.ts
+++ b/dist/exporters/utils.d.ts
@@ -1,7 +1,9 @@
 /// <reference types="plugin-typings" />
 import * as FigmaTypes from '../figma/types';
 import { Exportable, VariantProperty } from '../types';
-export declare function filterByNodeType<Type extends FigmaTypes.Node['type']>(type: Type): (obj?: FigmaTypes.Node | null) => obj is Extract<FigmaTypes.Document, {
+export declare function filterByNodeType<Type extends FigmaTypes.Node['type']>(type: Type): (obj?: FigmaTypes.Node | null) => obj is Extract<FigmaTypes.Component, {
+    type: Type;
+}> | Extract<FigmaTypes.Document, {
     type: Type;
 }> | Extract<FigmaTypes.Canvas, {
     type: Type;
@@ -27,8 +29,6 @@ export declare function filterByNodeType<Type extends FigmaTypes.Node['type']>(t
     type: Type;
 }> | Extract<FigmaTypes.Slice, {
     type: Type;
-}> | Extract<FigmaTypes.Component, {
-    type: Type;
 }> | Extract<FigmaTypes.ComponentSet, {
     type: Type;
 }> | Extract<FigmaTypes.Instance, {
@@ -46,7 +46,7 @@ export declare function findChildNodeWithTypeAndName<Type extends FigmaTypes.Nod
 export declare function getComponentNamePart(componentName: string, partKey: string): string;
 export declare const isValidVariantProperty: (variantProperty: string) => variantProperty is VariantProperty;
 export declare const isExportable: (exportable: string) => exportable is Exportable;
-export declare const isValidNodeType: (type: string) => type is "DOCUMENT" | "CANVAS" | "FRAME" | "GROUP" | "VECTOR" | "BOOLEAN_OPERATION" | "STAR" | "LINE" | "ELLIPSE" | "REGULAR_POLYGON" | "RECTANGLE" | "TEXT" | "SLICE" | "COMPONENT" | "COMPONENT_SET" | "INSTANCE";
+export declare const isValidNodeType: (type: string) => type is "INSTANCE" | "COMPONENT" | "DOCUMENT" | "CANVAS" | "FRAME" | "GROUP" | "VECTOR" | "BOOLEAN_OPERATION" | "STAR" | "LINE" | "ELLIPSE" | "REGULAR_POLYGON" | "RECTANGLE" | "TEXT" | "SLICE" | "COMPONENT_SET";
 export declare const isValidEffectType: (effect: FigmaTypes.Effect['type']) => boolean;
 export declare const isShadowEffectType: (effect: FigmaTypes.Effect['type']) => boolean;
 export declare const isValidGradientType: (gradientType: FigmaTypes.PaintType) => boolean;

--- a/dist/transformers/tokens.js
+++ b/dist/transformers/tokens.js
@@ -42,7 +42,7 @@ var getSpacingTokenSetTokens = function (tokenSet) { return ({
 var getBorderTokenSetTokens = function (tokenSet) { return ({
     'border-width': "".concat(tokenSet.weight, "px"),
     'border-radius': "".concat(tokenSet.radius, "px"),
-    'border-color': (0, convertColor_1.transformFigmaFillsToCssColor)(tokenSet.strokes).color,
+    'border-color': (0, convertColor_1.transformFigmaFillsToCssColor)(tokenSet.strokes, true).color,
 }); };
 var getTypographyTokenSetTokens = function (tokenSet) { return ({
     'font-family': "'".concat(tokenSet.fontFamily, "'"),
@@ -55,7 +55,7 @@ var getTypographyTokenSetTokens = function (tokenSet) { return ({
     'text-transform': (0, convertColor_1.transformFigmaTextCaseToCssTextTransform)(tokenSet.textCase)
 }); };
 var getFillTokenSetTokens = function (tokenSet) { return ({
-    'color': (0, convertColor_1.transformFigmaFillsToCssColor)(tokenSet.color).color,
+    'color': (0, convertColor_1.transformFigmaFillsToCssColor)(tokenSet.color, true).color,
 }); };
 var getEffectTokenSetTokens = function (tokenSet) { return ({
     'box-shadow': tokenSet.effect.map(convertColor_1.transformFigmaEffectToCssBoxShadow).filter(Boolean).join(', ') || 'none'

--- a/dist/utils/convertColor.d.ts
+++ b/dist/utils/convertColor.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="plugin-typings" />
 import * as FigmaTypes from '../figma/types';
 import { GradientObject } from '../types';
 /**
@@ -23,7 +22,7 @@ export declare function transformFigmaPaintToGradient(paint: FigmaTypes.Paint): 
 export declare function transformFigmaColorToHex(color: FigmaTypes.Color): string;
 export declare const transformFigmaColorToCssColor: (color: FigmaTypes.Color) => string;
 export declare function transformFigmaPaintToCssColor(paint: FigmaTypes.Paint, asLinearGradient?: boolean): string | null;
-export declare const transformFigmaFillsToCssColor: (fills: ReadonlyArray<FigmaTypes.Paint>, fallbackColor?: string, fallbackBlendMode?: string) => {
+export declare const transformFigmaFillsToCssColor: (fills: ReadonlyArray<FigmaTypes.Paint>, forceHexOrRgbaValue?: boolean) => {
     color: string;
     blend: string;
 };

--- a/src/transformers/tokens.ts
+++ b/src/transformers/tokens.ts
@@ -44,7 +44,7 @@ const getSpacingTokenSetTokens = (tokenSet: SpacingTokenSet): TokenDict => ({
 const getBorderTokenSetTokens = (tokenSet: BorderTokenSet): TokenDict => ({
   'border-width': `${tokenSet.weight}px`,
   'border-radius': `${tokenSet.radius}px`,
-  'border-color': transformFigmaFillsToCssColor(tokenSet.strokes).color,
+  'border-color': transformFigmaFillsToCssColor(tokenSet.strokes, true).color,
 });
 
 const getTypographyTokenSetTokens = (tokenSet: TypographyTokenSet): TokenDict => ({
@@ -59,7 +59,7 @@ const getTypographyTokenSetTokens = (tokenSet: TypographyTokenSet): TokenDict =>
 });
 
 const getFillTokenSetTokens = (tokenSet: FillTokenSet): TokenDict => ({
-  'color': transformFigmaFillsToCssColor(tokenSet.color).color,
+  'color': transformFigmaFillsToCssColor(tokenSet.color, true).color,
 });
 
 const getEffectTokenSetTokens = (tokenSet: EffectTokenSet): TokenDict => ({


### PR DESCRIPTION
Now supporting figma color blending. Updated fill (color) and border color tokens to strictly use rgba or hex value since blending using gradients is not supported by browsers for color and border-color properties.