### PR TITLE
Prevent redundant integration import

### DIFF
--- a/config/integrations/bootstrap/5.3/sass/main.scss
+++ b/config/integrations/bootstrap/5.3/sass/main.scss
@@ -1,6 +1,6 @@
 // ------------------------------------------------------------------
-// Bootstrap 5.2 - Handoff Design Tokens Map
-// Include this file in a Bootstrap 5.2 project to map Figma tokens
+// Bootstrap 5.3 - Handoff Design Tokens Map
+// Include this file in a Bootstrap 5.3 project to map Figma tokens
 // produced by the Handoff design system.
 // ------------------------------------------------------------------
 // Order is following:

--- a/config/integrations/bootstrap/5.3/sass/readme.md
+++ b/config/integrations/bootstrap/5.3/sass/readme.md
@@ -1,3 +1,3 @@
-# Bootstrap 5.2 Design Tokens
+# Bootstrap 5.3 Design Tokens
 
-These files map handoff design tokens to bootstrap 5.2.  
+These files map handoff design tokens to bootstrap 5.3.  

--- a/dist/utils/preview.js
+++ b/dist/utils/preview.js
@@ -98,7 +98,7 @@ var buildClientFiles = function () { return __awaiter(void 0, void 0, void 0, fu
                                                     integrationPath = path_1.default.join(handoff.workingPath, 'integration/sass');
                                                     if (fs_extra_1.default.existsSync(integrationPath)) {
                                                         fs_extra_1.default.readdirSync(integrationPath).filter(function (file) {
-                                                            return path_1.default.extname(file).toLowerCase() === '.scss';
+                                                            return path_1.default.extname(file).toLowerCase() === '.scss' && file !== 'main.scss';
                                                         }).forEach(function (file) {
                                                             content = content + "\n @import \"@integration/".concat(file, "\";");
                                                         });

--- a/src/utils/preview.ts
+++ b/src/utils/preview.ts
@@ -56,7 +56,7 @@ export const buildClientFiles = async (): Promise<string> => {
 
                     if (fs.existsSync(integrationPath)) {
                       fs.readdirSync(integrationPath).filter(file => {
-                        return path.extname(file).toLowerCase() === '.scss';
+                        return path.extname(file).toLowerCase() === '.scss' && file !== 'main.scss';
                       }).forEach(file => {
                         content = content + `\n @import "@integration/${file}";`;
                       });


### PR DESCRIPTION
Updated the code that searches for any extra integrations to import to skip the main integration file in order to prevent redundant (double) import.