### PR TITLE
Added destination cleanup prior to distributing the integration files.

### DIFF
--- a/dist/transformers/integration/index.js
+++ b/dist/transformers/integration/index.js
@@ -231,6 +231,10 @@ function integrationTransformer(documentationObject) {
                     templatesFolder = path_1.default.resolve(__dirname, '../../templates');
                     integrationsSass = path_1.default.resolve(integrationPath, 'sass');
                     integrationTemplates = path_1.default.resolve(integrationPath, 'templates');
+                    // clean dest
+                    fs_extra_1.default.removeSync(sassFolder);
+                    fs_extra_1.default.removeSync(templatesFolder);
+                    // copy to dest
                     fs_extra_1.default.copySync(integrationsSass, sassFolder);
                     fs_extra_1.default.copySync(integrationTemplates, templatesFolder);
                     mainScssFilePath = path_1.default.resolve(sassFolder, 'main.scss');

--- a/src/transformers/integration/index.ts
+++ b/src/transformers/integration/index.ts
@@ -180,6 +180,10 @@ export default async function integrationTransformer(documentationObject: Docume
   const templatesFolder = path.resolve(__dirname, '../../templates');
   const integrationsSass = path.resolve(integrationPath, 'sass');
   const integrationTemplates = path.resolve(integrationPath, 'templates');
+  // clean dest
+  fs.removeSync(sassFolder);
+  fs.removeSync(templatesFolder);
+  // copy to dest
   fs.copySync(integrationsSass, sassFolder);
   fs.copySync(integrationTemplates, templatesFolder);
   // replace tokens with actual values


### PR DESCRIPTION
When you run an integration build, the templates and sass files are cached in the build.  This change removes those cached files when doing the integration build.