### PR TITLE
Introduced a simple way of supporting bearer tokens.

### DIFF
--- a/dist/figma/api.js
+++ b/dist/figma/api.js
@@ -1,4 +1,15 @@
 "use strict";
+var __assign = (this && this.__assign) || function () {
+    __assign = Object.assign || function(t) {
+        for (var s, i = 1, n = arguments.length; i < n; i++) {
+            s = arguments[i];
+            for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
+                t[p] = s[p];
+        }
+        return t;
+    };
+    return __assign.apply(this, arguments);
+};
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
@@ -12,9 +23,7 @@ var counter = 0;
 var getFile = function (fileId, accessToken) {
     counter++;
     return figmaRestApi.get('files/' + fileId, {
-        headers: {
-            'X-Figma-Token': accessToken,
-        },
+        headers: __assign({}, getFigmaAuthHeaders(accessToken)),
     });
 };
 exports.getFile = getFile;
@@ -27,57 +36,48 @@ exports.getFile = getFile;
 var getFileComponent = function (fileId, accessToken) {
     counter++;
     return figmaRestApi.get('files/' + fileId + '/components', {
-        headers: {
-            'X-Figma-Token': accessToken,
-        },
+        headers: __assign({}, getFigmaAuthHeaders(accessToken)),
     });
 };
 exports.getFileComponent = getFileComponent;
 var getFileNodes = function (fileId, ids, accessToken) {
     counter++;
     return figmaRestApi.get('files/' + fileId + '/nodes?ids=' + ids.join(','), {
-        headers: {
-            'X-Figma-Token': accessToken,
-        },
+        headers: __assign({}, getFigmaAuthHeaders(accessToken)),
     });
 };
 exports.getFileNodes = getFileNodes;
 var getAssetURL = function (fileId, ids, extension, accessToken) {
     counter++;
     return figmaRestApi.get('images/' + fileId + '/?ids=' + ids.join(',') + '&format=' + extension, {
-        headers: {
-            'X-Figma-Token': accessToken,
-        },
+        headers: __assign({}, getFigmaAuthHeaders(accessToken)),
     });
 };
 exports.getAssetURL = getAssetURL;
 var getFileStyles = function (fileId, accessToken) {
     counter++;
     return figmaRestApi.get('files/' + fileId + '/styles', {
-        headers: {
-            'X-Figma-Token': accessToken,
-        },
+        headers: __assign({}, getFigmaAuthHeaders(accessToken)),
     });
 };
 exports.getFileStyles = getFileStyles;
 var getComponentSets = function (fileId, accessToken) {
     counter++;
     return figmaRestApi.get('files/' + fileId + '/component_sets', {
-        headers: {
-            'X-Figma-Token': accessToken,
-        },
+        headers: __assign({}, getFigmaAuthHeaders(accessToken)),
     });
 };
 exports.getComponentSets = getComponentSets;
 var getComponentSetNodes = function (fileId, ids, accessToken) {
     counter++;
     return figmaRestApi.get('files/' + fileId + '/nodes?ids=' + ids.join(','), {
-        headers: {
-            'X-Figma-Token': accessToken,
-        },
+        headers: __assign({}, getFigmaAuthHeaders(accessToken)),
     });
 };
 exports.getComponentSetNodes = getComponentSetNodes;
 var getRequestCount = function () { return counter; };
 exports.getRequestCount = getRequestCount;
 exports.default = figmaRestApi;
+var getFigmaAuthHeaders = function (accessToken) {
+    return accessToken.startsWith('bearer\\') ? { Authorization: "Bearer ".concat(accessToken.substring(7)) } : { 'X-Figma-Token': accessToken };
+};

--- a/dist/figma/api.js
+++ b/dist/figma/api.js
@@ -79,5 +79,5 @@ var getRequestCount = function () { return counter; };
 exports.getRequestCount = getRequestCount;
 exports.default = figmaRestApi;
 var getFigmaAuthHeaders = function (accessToken) {
-    return accessToken.startsWith('bearer\\') ? { Authorization: "Bearer ".concat(accessToken.substring(7)) } : { 'X-Figma-Token': accessToken };
+    return accessToken.startsWith('Bearer ') ? { 'Authorization': accessToken } : { 'X-Figma-Token': accessToken };
 };

--- a/src/figma/api.ts
+++ b/src/figma/api.ts
@@ -11,7 +11,7 @@ export const getFile = (fileId: string, accessToken: string) => {
   counter++;
   return figmaRestApi.get<FileResponse>('files/' + fileId, {
     headers: {
-      'X-Figma-Token': accessToken,
+      ...getFigmaAuthHeaders(accessToken)
     },
   });
 };
@@ -25,7 +25,7 @@ export const getFileComponent = (fileId: string, accessToken: string) => {
   counter++;
   return figmaRestApi.get<FileComponentsResponse>('files/' + fileId + '/components', {
     headers: {
-      'X-Figma-Token': accessToken,
+      ...getFigmaAuthHeaders(accessToken)
     },
   });
 };
@@ -34,7 +34,7 @@ export const getFileNodes = (fileId: string, ids: string[], accessToken: string)
   counter++;
   return figmaRestApi.get<FileNodesResponse>('files/' + fileId + '/nodes?ids=' + ids.join(','), {
     headers: {
-      'X-Figma-Token': accessToken,
+      ...getFigmaAuthHeaders(accessToken)
     },
   });
 };
@@ -43,7 +43,7 @@ export const getAssetURL = (fileId: string, ids: string[], extension: string, ac
   counter++;
   return figmaRestApi.get<FileImageResponse>('images/' + fileId + '/?ids=' + ids.join(',') + '&format=' + extension, {
     headers: {
-      'X-Figma-Token': accessToken,
+      ...getFigmaAuthHeaders(accessToken)
     },
   });
 };
@@ -52,7 +52,7 @@ export const getFileStyles = (fileId: string, accessToken: string) => {
   counter++;
   return figmaRestApi.get<FileStylesResponse>('files/' + fileId + '/styles', {
     headers: {
-      'X-Figma-Token': accessToken,
+      ...getFigmaAuthHeaders(accessToken)
     },
   });
 };
@@ -61,7 +61,7 @@ export const getComponentSets = (fileId: string, accessToken: string) => {
   counter++;
   return figmaRestApi.get<FileComponentSetsResponse>('files/' + fileId + '/component_sets', {
     headers: {
-      'X-Figma-Token': accessToken,
+      ...getFigmaAuthHeaders(accessToken)
     },
   });
 };
@@ -70,10 +70,13 @@ export const getComponentSetNodes = (fileId: string, ids: string[], accessToken:
   counter++;
   return figmaRestApi.get<FileNodesResponse>('files/' + fileId + '/nodes?ids=' + ids.join(','), {
     headers: {
-      'X-Figma-Token': accessToken,
+      ...getFigmaAuthHeaders(accessToken)
     },
   });
 };
 
 export const getRequestCount = () => counter;
 export default figmaRestApi;
+
+const getFigmaAuthHeaders = (accessToken: string): { [header: string]: string } =>
+  accessToken.startsWith('bearer\\') ? { Authorization: `Bearer ${accessToken.substring(7)}` } : { 'X-Figma-Token': accessToken };

--- a/src/figma/api.ts
+++ b/src/figma/api.ts
@@ -79,4 +79,4 @@ export const getRequestCount = () => counter;
 export default figmaRestApi;
 
 const getFigmaAuthHeaders = (accessToken: string): { [header: string]: string } =>
-  accessToken.startsWith('bearer\\') ? { Authorization: `Bearer ${accessToken.substring(7)}` } : { 'X-Figma-Token': accessToken };
+  accessToken.startsWith('Bearer ') ? { 'Authorization': accessToken } : { 'X-Figma-Token': accessToken };


### PR DESCRIPTION
This allows handoff to be used in a larger application or API by accepting Figma oauth bearer tokens along side issued API tokens.  

Currently, Handoff looks for an env var `DEV_ACCESS_TOKEN` and sends that to Figma as authorization.  This looks at the provided token, and if that token is a `Bearer` token, it will send it to Figma as an authorization token rather than an `X-Figma-Token`