### PR TITLE
Remove default options and hard coded string replace rules

### DIFF
--- a/config/exportables/components/alert.json
+++ b/config/exportables/components/alert.json
@@ -14,7 +14,6 @@
       }
     },
     "transformer": {
-      "cssRootClass": "alert",
       "tokenNameSegments": [
         "${Component}",
         "${Type}",

--- a/config/exportables/components/button.json
+++ b/config/exportables/components/button.json
@@ -16,7 +16,6 @@
       }
     },
     "transformer": {
-      "cssRootClass": "btn",
       "tokenNameSegments": [
         "${Component}",
         "${Type}",

--- a/dist/config.js
+++ b/dist/config.js
@@ -49,30 +49,7 @@ var defaultConfig = function () {
             base_path: '',
         },
         figma: {
-            options: {
-                shared: {
-                    defaults: {
-                        Theme: 'light',
-                        State: 'default',
-                        Type: 'default',
-                        Activity: '',
-                        Layout: '',
-                        Size: '',
-                    },
-                },
-                transformer: {
-                    replace: {
-                        State: {
-                            default: '',
-                        },
-                        Size: {
-                            small: 'sm',
-                            medium: 'md',
-                            large: 'lg',
-                        },
-                    },
-                },
-            },
+            options: {},
             definitions: [
                 'components/alert',
                 'components/button',

--- a/dist/exporters/components/index.js
+++ b/dist/exporters/components/index.js
@@ -114,7 +114,7 @@ var getComponentSetComponentDefinition = function (componentSet) {
                 sharedComponentVariants: metadata.sharedVariants,
             },
             transformer: {
-                cssRootClass: name === 'button' ? 'btn' : name,
+                cssRootClass: name,
                 tokenNameSegments: metadata.tokenNameSegments,
                 replace: groupReplaceRules(metadata.replacements),
             },
@@ -281,7 +281,7 @@ var getComponentPropertyWithParams = function (variantProperty) {
  * @deprecated Will be removed before 1.0.0 release.
  */
 var getComponentDefinitionForLegacyComponentDefinition = function (componentSet, legacyDefinition) {
-    var _a, _b, _c, _d, _e, _f, _g, _h;
+    var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p;
     var supportedVariantProps = __spreadArray(__spreadArray([], (_d = (_c = (_b = (_a = legacyDefinition === null || legacyDefinition === void 0 ? void 0 : legacyDefinition.options) === null || _a === void 0 ? void 0 : _a.exporter) === null || _b === void 0 ? void 0 : _b.supportedVariantProps) === null || _c === void 0 ? void 0 : _c.design) !== null && _d !== void 0 ? _d : [], true), (_h = (_g = (_f = (_e = legacyDefinition === null || legacyDefinition === void 0 ? void 0 : legacyDefinition.options) === null || _e === void 0 ? void 0 : _e.exporter) === null || _f === void 0 ? void 0 : _f.supportedVariantProps) === null || _g === void 0 ? void 0 : _g.layout) !== null && _h !== void 0 ? _h : [], true);
     var definitionSupportedVariantProperties = supportedVariantProps.map(function (variantProp) { return variantProp.replace(/ *\([^)]*\) */g, ''); });
     var definitionSupportedVariantPropertiesWithShareParams = supportedVariantProps.filter(function (variantProperty) { return variantProperty.match((/ *\([^)]*\) */g)); });
@@ -324,16 +324,16 @@ var getComponentDefinitionForLegacyComponentDefinition = function (componentSet,
         group: legacyDefinition.group,
         options: {
             shared: {
-                defaults: legacyDefinition.options.shared.defaults,
+                defaults: (_k = (_j = legacyDefinition.options.shared) === null || _j === void 0 ? void 0 : _j.defaults) !== null && _k !== void 0 ? _k : {},
             },
             exporter: {
                 variantProperties: variantProperties.map(function (variantProp) { return variantProp.name; }),
                 sharedComponentVariants: sharedComponentVariants,
             },
             transformer: {
-                cssRootClass: legacyDefinition.options.transformer.cssRootClass,
-                tokenNameSegments: legacyDefinition.options.transformer.tokenNameSegments,
-                replace: legacyDefinition.options.transformer.replace,
+                cssRootClass: (_m = (_l = legacyDefinition.options.transformer) === null || _l === void 0 ? void 0 : _l.cssRootClass) !== null && _m !== void 0 ? _m : legacyDefinition.id,
+                tokenNameSegments: (_o = legacyDefinition.options.transformer) === null || _o === void 0 ? void 0 : _o.tokenNameSegments,
+                replace: (_p = legacyDefinition.options.transformer) === null || _p === void 0 ? void 0 : _p.replace,
             },
         },
         parts: legacyDefinition.parts,

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,5 @@
 import fs from 'fs-extra';
 import path from 'path';
-import Handoff from '.';
 import { ClientConfig, Config } from './types/config';
 
 export interface ImageStyle {
@@ -41,30 +40,7 @@ export const defaultConfig = (): Config => ({
     base_path: '',
   },
   figma: {
-    options: {
-      shared: {
-        defaults: {
-          Theme: 'light',
-          State: 'default',
-          Type: 'default',
-          Activity: '',
-          Layout: '',
-          Size: '',
-        },
-      },
-      transformer: {
-        replace: {
-          State: {
-            default: '',
-          },
-          Size: {
-            small: 'sm',
-            medium: 'md',
-            large: 'lg',
-          },
-        },
-      },
-    },
+    options: {},
     definitions: [
       'components/alert',
       'components/button',

--- a/src/exporters/components/index.ts
+++ b/src/exporters/components/index.ts
@@ -65,7 +65,7 @@ const getComponentSetComponentDefinition = (componentSet: FigmaTypes.ComponentSe
         sharedComponentVariants: metadata.sharedVariants,
       },
       transformer: {
-        cssRootClass: name === 'button' ? 'btn' : name, // TODO
+        cssRootClass: name,
         tokenNameSegments: metadata.tokenNameSegments,
         replace: groupReplaceRules(metadata.replacements),
       },
@@ -338,16 +338,16 @@ const getComponentDefinitionForLegacyComponentDefinition = (componentSet: FigmaT
     group: legacyDefinition.group,
     options: {
       shared: {
-        defaults: legacyDefinition.options.shared.defaults,
+        defaults: legacyDefinition.options.shared?.defaults ?? {},
       },
       exporter: {
         variantProperties: variantProperties.map((variantProp) => variantProp.name),
         sharedComponentVariants,
       },
       transformer: {
-        cssRootClass: legacyDefinition.options.transformer.cssRootClass,
-        tokenNameSegments: legacyDefinition.options.transformer.tokenNameSegments,
-        replace: legacyDefinition.options.transformer.replace,
+        cssRootClass: legacyDefinition.options.transformer?.cssRootClass ?? legacyDefinition.id,
+        tokenNameSegments: legacyDefinition.options.transformer?.tokenNameSegments,
+        replace: legacyDefinition.options.transformer?.replace,
       },
     },
     parts: legacyDefinition.parts,


### PR DESCRIPTION
With this PR:
* All default options will be removed from the configuration (defaults and replace rules).
* All cssRootClass properties will be removed from all legacy exportable schemas.
* Hard coded cssRootClass "button" to "btn" replacement rule will be removed.