### PR TITLE
Patch to fix a bug where a component is published by not anntoated

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -26,6 +26,8 @@ before building or serving the app
 the error messages were not clear, and didn't explain that you could use `--debug`
 to make them more clear. The error message has been improved and now alerts
 users to the `--debug` flag to help them debug their integration.
+- When ejecting an integration with the `--force` flag, the force now triggers
+an overwrite rather than failing.
 
 ## [0.13.1] - 2024-09-17
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.2] - 2024-09-18
+This release addresses several developer experience issues
+
+### Bugfixes
+- When an integration compiles SASS code, the token injection was injecting 
+components that had no instances in Figma. This causes integrations to fail if
+the designer had published a component, but not annotated them in Figma with the
+plugin. This release checks to see if the component has any instances in the 
+Figma export and skips injection for components that are not yet annotated in
+Figma
+- When running `eject:integration` or `make:integration` the default integration
+is exported, but it is not built.  This causes a weird developer experience
+if you try to `build:app` without `build:integration` first.  This patch adds
+the `build:integration` logic to execute after `eject` or `make` as well as before
+`build:app` to ensure that if an integration exists, the integration is built
+before building or serving the app
+- If an an `build:app` fails while building the integration preview sass code
+the error messages were not clear, and didn't explain that you could use `--debug`
+to make them more clear. The error message has been improved and now alerts
+users to the `--debug` flag to help them debug their integration.
+
 ## [0.13.1] - 2024-09-17
 
 This release fixes a couple of small path issues that affect running 0.13.0 from the global path.

--- a/dist/app.js
+++ b/dist/app.js
@@ -61,6 +61,7 @@ var fs_extra_1 = __importDefault(require("fs-extra"));
 var chokidar_1 = __importDefault(require("chokidar"));
 var chalk_1 = __importDefault(require("chalk"));
 var preview_1 = require("./utils/preview");
+var pipeline_1 = require("./pipeline");
 var getWorkingPublicPath = function (handoff) {
     var paths = [
         path_1.default.resolve(handoff.workingPath, "public-".concat(handoff.config.figma_project_id)),
@@ -147,17 +148,20 @@ var buildApp = function (handoff) { return __awaiter(void 0, void 0, void 0, fun
                 if (!fs_extra_1.default.existsSync(path_1.default.resolve(handoff.workingPath, handoff.exportsDirectory, handoff.config.figma_project_id, 'tokens.json'))) {
                     throw new Error('Tokens not exported. Run `handoff-app fetch` first.');
                 }
+                return [4 /*yield*/, (0, pipeline_1.buildIntegrationOnly)(handoff)];
+            case 1:
+                _a.sent();
                 // Build client preview styles
                 return [4 /*yield*/, (0, preview_1.buildClientFiles)(handoff)
                         .then(function (value) { return !!value && console.log(chalk_1.default.green(value)); })
                         .catch(function (error) {
                         throw new Error(error);
                     })];
-            case 1:
+            case 2:
                 // Build client preview styles
                 _a.sent();
                 return [4 /*yield*/, prepareProjectApp(handoff)];
-            case 2:
+            case 3:
                 appPath = _a.sent();
                 // Build app
                 return [4 /*yield*/, (0, next_build_1.nextBuild)({
@@ -168,7 +172,7 @@ var buildApp = function (handoff) { return __awaiter(void 0, void 0, void 0, fun
                         experimentalTurbo: false,
                         experimentalBuildMode: 'default',
                     }, appPath)];
-            case 3:
+            case 4:
                 // Build app
                 _a.sent();
                 outputRoot = path_1.default.resolve(handoff.workingPath, handoff.sitesDirectory);

--- a/dist/app.js
+++ b/dist/app.js
@@ -148,8 +148,10 @@ var buildApp = function (handoff) { return __awaiter(void 0, void 0, void 0, fun
                 if (!fs_extra_1.default.existsSync(path_1.default.resolve(handoff.workingPath, handoff.exportsDirectory, handoff.config.figma_project_id, 'tokens.json'))) {
                     throw new Error('Tokens not exported. Run `handoff-app fetch` first.');
                 }
+                // If we are building the app, ensure the integration is built first
                 return [4 /*yield*/, (0, pipeline_1.buildIntegrationOnly)(handoff)];
             case 1:
+                // If we are building the app, ensure the integration is built first
                 _a.sent();
                 // Build client preview styles
                 return [4 /*yield*/, (0, preview_1.buildClientFiles)(handoff)

--- a/dist/cli.js
+++ b/dist/cli.js
@@ -80,7 +80,7 @@ var showHelp = function () {
  * Show the help message
  */
 var showVersion = function () {
-    cliError('Handoff App - 0.13.1', 2);
+    cliError('Handoff App - 0.13.2', 2);
 };
 /**
  * Define a CLI error

--- a/dist/cli/eject.js
+++ b/dist/cli/eject.js
@@ -84,7 +84,9 @@ var makeIntegration = function (handoff) { return __awaiter(void 0, void 0, void
                     }
                 }
                 integrationPath = (0, integration_1.getPathToIntegration)(handoff, true);
-                fs_extra_1.default.copySync(integrationPath, workingPath, { overwrite: false });
+                fs_extra_1.default.copySync(integrationPath, workingPath, { overwrite: handoff.force ? true : false });
+                if (handoff.force)
+                    handoff.force = false;
                 return [4 /*yield*/, (0, pipeline_1.buildIntegrationOnly)(handoff)];
             case 1:
                 _a.sent();

--- a/dist/cli/eject.js
+++ b/dist/cli/eject.js
@@ -45,6 +45,7 @@ var fs_extra_1 = __importDefault(require("fs-extra"));
 var chalk_1 = __importDefault(require("chalk"));
 var integration_1 = require("../transformers/integration");
 var config_1 = require("../config");
+var pipeline_1 = require("../pipeline");
 /**
  * Eject the config to the working directory
  * @param handoff
@@ -72,18 +73,24 @@ exports.ejectConfig = ejectConfig;
 var makeIntegration = function (handoff) { return __awaiter(void 0, void 0, void 0, function () {
     var config, workingPath, integrationPath;
     return __generator(this, function (_a) {
-        config = handoff.config;
-        workingPath = path_1.default.resolve(path_1.default.join(handoff.workingPath, 'integration'));
-        if (fs_extra_1.default.existsSync(workingPath)) {
-            if (!handoff.force) {
-                console.log(chalk_1.default.red("An integration already exists in the working directory. Use the --force flag to overwrite."));
-                return [2 /*return*/];
-            }
+        switch (_a.label) {
+            case 0:
+                config = handoff.config;
+                workingPath = path_1.default.resolve(path_1.default.join(handoff.workingPath, 'integration'));
+                if (fs_extra_1.default.existsSync(workingPath)) {
+                    if (!handoff.force) {
+                        console.log(chalk_1.default.red("An integration already exists in the working directory. Use the --force flag to overwrite."));
+                        return [2 /*return*/];
+                    }
+                }
+                integrationPath = (0, integration_1.getPathToIntegration)(handoff, true);
+                fs_extra_1.default.copySync(integrationPath, workingPath, { overwrite: false });
+                return [4 /*yield*/, (0, pipeline_1.buildIntegrationOnly)(handoff)];
+            case 1:
+                _a.sent();
+                console.log(chalk_1.default.green("Integration has been successfully created! Path: ".concat(workingPath)));
+                return [2 /*return*/, handoff];
         }
-        integrationPath = (0, integration_1.getPathToIntegration)(handoff, true);
-        fs_extra_1.default.copySync(integrationPath, workingPath, { overwrite: false });
-        console.log(chalk_1.default.green("Integration has been successfully created! Path: ".concat(workingPath)));
-        return [2 /*return*/, handoff];
     });
 }); };
 exports.makeIntegration = makeIntegration;

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -56,4 +56,5 @@ declare class Handoff {
     postIntegration(callback: (documentationObject: DocumentationObject, data: HookReturn[]) => HookReturn[]): void;
     modifyWebpackConfig(callback: (webpackConfig: webpack.Configuration) => webpack.Configuration): void;
 }
+export declare const initIntegrationObject: (workingPath: string) => IntegrationObject;
 export default Handoff;

--- a/dist/index.js
+++ b/dist/index.js
@@ -73,6 +73,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.initIntegrationObject = void 0;
 var config_1 = require("./config");
 var fs_extra_1 = __importDefault(require("fs-extra"));
 var path_1 = __importDefault(require("path"));
@@ -117,7 +118,7 @@ var Handoff = /** @class */ (function () {
         this.config = this.hooks.init(this.config);
         this.exportsDirectory = (_a = config.exportsOutputDirectory) !== null && _a !== void 0 ? _a : this.exportsDirectory;
         this.sitesDirectory = (_b = config.sitesOutputDirectory) !== null && _b !== void 0 ? _b : this.exportsDirectory;
-        this.integrationObject = initIntegrationObject(this.workingPath);
+        this.integrationObject = (0, exports.initIntegrationObject)(this.workingPath);
         return this;
     };
     Handoff.prototype.preRunner = function (validate) {
@@ -414,6 +415,7 @@ var initIntegrationObject = function (workingPath) {
     var integration = JSON.parse(buffer.toString());
     return (0, integration_2.prepareIntegrationObject)(integration, integrationPath);
 };
+exports.initIntegrationObject = initIntegrationObject;
 var validateConfig = function (config) {
     if (!config.figma_project_id && !process.env.HANDOFF_FIGMA_PROJECT_ID) {
         // check to see if we can get this from the env

--- a/dist/pipeline.js
+++ b/dist/pipeline.js
@@ -88,6 +88,7 @@ var index_3 = __importStar(require("./transformers/integration/index"));
 var index_4 = __importDefault(require("./transformers/font/index"));
 var index_5 = __importDefault(require("./transformers/preview/index"));
 var app_1 = __importDefault(require("./app"));
+var _1 = require(".");
 var sd_1 = __importDefault(require("./transformers/sd"));
 var map_1 = __importDefault(require("./transformers/map"));
 var lodash_1 = require("lodash");
@@ -433,7 +434,7 @@ var buildRecipe = function (handoff) { return __awaiter(void 0, void 0, void 0, 
                     var match;
                     var regex = new RegExp(TOKEN_REGEX, 'g');
                     var _loop_1 = function () {
-                        var _1 = match[0], __ = match[1], component = match[2], part = match[3], variants = match[4], cssProperty = match[5];
+                        var _2 = match[0], __ = match[1], component = match[2], part = match[3], variants = match[4], cssProperty = match[5];
                         var componentRecord = records.components.find(function (c) { return c.name === component; });
                         if (!componentRecord) {
                             componentRecord = { name: component, common: { parts: [] }, recipes: [] };
@@ -534,6 +535,8 @@ var buildIntegrationOnly = function (handoff) { return __awaiter(void 0, void 0,
             case 1:
                 documentationObject = _a.sent();
                 if (!documentationObject) return [3 /*break*/, 4];
+                // Ensure that the integration object is set if possible
+                handoff.integrationObject = (0, _1.initIntegrationObject)(handoff.workingPath);
                 return [4 /*yield*/, buildIntegration(handoff, documentationObject)];
             case 2:
                 _a.sent();

--- a/dist/transformers/integration/index.d.ts
+++ b/dist/transformers/integration/index.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="node" />
 import archiver from 'archiver';
 import * as stream from 'node:stream';
 import { DocumentationObject } from '../../types';

--- a/dist/transformers/integration/index.js
+++ b/dist/transformers/integration/index.js
@@ -184,7 +184,7 @@ var zipTokens = function (dirPath, destination) { return __awaiter(void 0, void 
 }); };
 exports.zipTokens = zipTokens;
 var buildIntegration = function (sourcePath, destPath, documentationObject, rootPath, rootReturnPath) { return __awaiter(void 0, void 0, void 0, function () {
-    var items, components, _i, items_1, item, sourceItemPath, destItemPath, stat, content, template, renderedContent;
+    var items, components, componentsWithInstances, _i, items_1, item, sourceItemPath, destItemPath, stat, content, template, renderedContent;
     return __generator(this, function (_a) {
         switch (_a.label) {
             case 0:
@@ -193,6 +193,7 @@ var buildIntegration = function (sourcePath, destPath, documentationObject, root
             case 1:
                 items = _a.sent();
                 components = Object.keys(documentationObject.components);
+                componentsWithInstances = components.filter(function (component) { return documentationObject.components[component].instances.length > 0; });
                 _i = 0, items_1 = items;
                 _a.label = 2;
             case 2:
@@ -229,7 +230,7 @@ var buildIntegration = function (sourcePath, destPath, documentationObject, root
                 // Ensure the directory exists before writing the file
                 _a.sent();
                 // Write the rendered content to the destination path
-                return [4 /*yield*/, fs_extra_1.default.writeFile(destItemPath, replaceHandoffImportTokens(renderedContent, components, path_1.default.parse(destItemPath).dir, rootPath, rootReturnPath !== null && rootReturnPath !== void 0 ? rootReturnPath : '../'))];
+                return [4 /*yield*/, fs_extra_1.default.writeFile(destItemPath, replaceHandoffImportTokens(renderedContent, componentsWithInstances, path_1.default.parse(destItemPath).dir, rootPath, rootReturnPath !== null && rootReturnPath !== void 0 ? rootReturnPath : '../'))];
             case 9:
                 // Write the rendered content to the destination path
                 _a.sent();

--- a/dist/transformers/integration/index.js
+++ b/dist/transformers/integration/index.js
@@ -86,9 +86,11 @@ var getPathToIntegration = function (handoff, resolveTemplatePath) {
     if (!handoff) {
         throw Error('Handoff not initialized');
     }
-    var integrationPath = path_1.default.resolve(path_1.default.join(handoff.workingPath, 'integration'));
-    if (fs_extra_1.default.existsSync(integrationPath)) {
-        return integrationPath;
+    if (!handoff.force) {
+        var integrationPath = path_1.default.resolve(path_1.default.join(handoff.workingPath, 'integration'));
+        if (fs_extra_1.default.existsSync(integrationPath)) {
+            return integrationPath;
+        }
     }
     if (resolveTemplatePath) {
         return path_1.default.resolve(path_1.default.join(handoff.modulePath, 'config', 'templates', 'integration'));

--- a/dist/transformers/utils.d.ts
+++ b/dist/transformers/utils.d.ts
@@ -24,20 +24,14 @@ export declare const formatComponentCodeBlockComment: (component: ComponentInsta
  * @param options
  * @returns
  */
-export declare const formatTokenName: (tokenType: TokenType, componentName: string, componentVariantProps: [
-    string,
-    string
-][], part: string, property: string, options?: IntegrationObjectComponentOptions) => string;
+export declare const formatTokenName: (tokenType: TokenType, componentName: string, componentVariantProps: [string, string][], part: string, property: string, options?: IntegrationObjectComponentOptions) => string;
 /**
  * Returns the token name segments
  * @param component
  * @param options
  * @returns
  */
-export declare const getTokenNameSegments: (componentName: string, componentVariantProps: [
-    string,
-    string
-][], part: string, property: string, options?: IntegrationObjectComponentOptions) => string[];
+export declare const getTokenNameSegments: (componentName: string, componentVariantProps: [string, string][], part: string, property: string, options?: IntegrationObjectComponentOptions) => string[];
 /**
  * Normalizes the token name variable (specifier) by considering if the value should be replaced
  * with some other value based replace rules defined in the transformer options of the component

--- a/dist/utils/preview.js
+++ b/dist/utils/preview.js
@@ -137,18 +137,24 @@ var buildClientFiles = function (handoff) { return __awaiter(void 0, void 0, voi
                 compile.run(function (err, stats) {
                     var _a, _b;
                     if (err) {
-                        var error = 'Errors encountered trying to build preview styles.\n';
+                        var error = chalk_1.default.red('Errors encountered trying to build preview styles.') + '\n  The integration sass expects a token that isn\'t found in your Figma component.\n';
                         if (handoff.debug) {
-                            error += err.stack || err;
+                            error += chalk_1.default.yellow('\n\n---------- Sass Build Error Trace ---------- \n') + err.stack || err;
+                        }
+                        else {
+                            error += 'Add the --debug flag to see the full error trace\n\n';
                         }
                         return reject(error);
                     }
                     if (stats) {
                         if (stats.hasErrors()) {
                             var buildErrors = (_a = stats.compilation.errors) === null || _a === void 0 ? void 0 : _a.map(function (err) { return err.message; });
-                            var error = 'Errors encountered trying to build preview styles.\n';
+                            var error = chalk_1.default.red('Errors encountered trying to build preview styles.') + '\nThe integration sass expects a token that isn\'t found in your Figma component.\n';
                             if (handoff.debug) {
-                                error += buildErrors;
+                                error += chalk_1.default.yellow('\n\n---------- Sass Build Error Trace ---------- \n') + buildErrors;
+                            }
+                            else {
+                                error += 'Add the --debug flag to see the full error trace\n\n';
                             }
                             return reject(error);
                         }

--- a/src/app.ts
+++ b/src/app.ts
@@ -9,6 +9,7 @@ import fs from 'fs-extra';
 import chokidar from 'chokidar';
 import chalk from 'chalk';
 import { buildClientFiles } from './utils/preview';
+import { buildIntegrationOnly } from './pipeline';
 
 const getWorkingPublicPath = (handoff: Handoff): string | null => {
   const paths = [
@@ -79,6 +80,9 @@ const buildApp = async (handoff: Handoff): Promise<void> => {
   if (!fs.existsSync(path.resolve(handoff.workingPath, handoff.exportsDirectory, handoff.config.figma_project_id, 'tokens.json'))) {
     throw new Error('Tokens not exported. Run `handoff-app fetch` first.');
   }
+
+  // If we are building the app, ensure the integration is built first
+  await buildIntegrationOnly(handoff);
 
   // Build client preview styles
   await buildClientFiles(handoff)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -57,7 +57,7 @@ const showHelp = () => {
  * Show the help message
  */
 const showVersion = () => {
-  cliError('Handoff App - 0.13.1', 2);
+  cliError('Handoff App - 0.13.2', 2);
 };
 
 /**

--- a/src/cli/eject.ts
+++ b/src/cli/eject.ts
@@ -4,6 +4,7 @@ import fs from 'fs-extra';
 import chalk from 'chalk';
 import { getPathToIntegration } from '../transformers/integration';
 import { getClientConfig } from '../config';
+import { buildIntegrationOnly } from '../pipeline';
 
 /**
  * Eject the config to the working directory
@@ -41,8 +42,8 @@ export const makeIntegration = async (handoff: Handoff) => {
   // perform integration ejection
   const integrationPath = getPathToIntegration(handoff, true);
   fs.copySync(integrationPath, workingPath, { overwrite: false });
+  await buildIntegrationOnly(handoff);
   console.log(chalk.green(`Integration has been successfully created! Path: ${workingPath}`));
-
   return handoff;
 };
 

--- a/src/cli/eject.ts
+++ b/src/cli/eject.ts
@@ -41,7 +41,8 @@ export const makeIntegration = async (handoff: Handoff) => {
 
   // perform integration ejection
   const integrationPath = getPathToIntegration(handoff, true);
-  fs.copySync(integrationPath, workingPath, { overwrite: false });
+  fs.copySync(integrationPath, workingPath, { overwrite: handoff.force ? true : false });
+  if (handoff.force) handoff.force = false;
   await buildIntegrationOnly(handoff);
   console.log(chalk.green(`Integration has been successfully created! Path: ${workingPath}`));
   return handoff;

--- a/src/index.ts
+++ b/src/index.ts
@@ -219,7 +219,8 @@ const initConfig = (configOverride?: any): Config => {
   return returnConfig;
 };
 
-const initIntegrationObject = (workingPath: string): IntegrationObject => {
+
+export const initIntegrationObject = (workingPath: string): IntegrationObject => {
   const integrationPath = path.join(workingPath, 'integration');
 
   if (!fs.existsSync(integrationPath)) {

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -19,7 +19,7 @@ import integrationTransformer, { getPathToIntegration } from './transformers/int
 import fontTransformer from './transformers/font/index';
 import previewTransformer from './transformers/preview/index';
 import buildApp from './app';
-import Handoff from '.';
+import Handoff, { initIntegrationObject } from '.';
 import sdTransformer from './transformers/sd';
 import mapTransformer from './transformers/map';
 import { merge } from 'lodash';
@@ -429,6 +429,8 @@ export const buildRecipe = async (handoff: Handoff) => {
 export const buildIntegrationOnly = async (handoff: Handoff) => {
   const documentationObject: DocumentationObject | undefined = await readPrevJSONFile(tokensFilePath(handoff));
   if (documentationObject) {
+    // Ensure that the integration object is set if possible
+    handoff.integrationObject = initIntegrationObject(handoff.workingPath);
     await buildIntegration(handoff, documentationObject);
     await buildPreviews(handoff, documentationObject);
   }

--- a/src/transformers/integration/index.ts
+++ b/src/transformers/integration/index.ts
@@ -48,13 +48,13 @@ export const getPathToIntegration = (handoff: Handoff, resolveTemplatePath: bool
   if (!handoff) {
     throw Error('Handoff not initialized');
   }
+  if (!handoff.force) {
+    const integrationPath = path.resolve(path.join(handoff.workingPath, 'integration'));
 
-  const integrationPath = path.resolve(path.join(handoff.workingPath, 'integration'));
-
-  if (fs.existsSync(integrationPath)) {
-    return integrationPath;
+    if (fs.existsSync(integrationPath)) {
+      return integrationPath;
+    }
   }
-
   if (resolveTemplatePath) {
     return path.resolve(path.join(handoff.modulePath, 'config', 'templates', 'integration'));
   }
@@ -161,7 +161,16 @@ const buildIntegration = async (
       // Ensure the directory exists before writing the file
       await fs.ensureDir(path.dirname(destItemPath));
       // Write the rendered content to the destination path
-      await fs.writeFile(destItemPath, replaceHandoffImportTokens(renderedContent, componentsWithInstances, path.parse(destItemPath).dir, rootPath, rootReturnPath ?? '../'));
+      await fs.writeFile(
+        destItemPath,
+        replaceHandoffImportTokens(
+          renderedContent,
+          componentsWithInstances,
+          path.parse(destItemPath).dir,
+          rootPath,
+          rootReturnPath ?? '../'
+        )
+      );
     }
   }
 };
@@ -335,7 +344,13 @@ interface IntegrationTemplateContext {
   documentationObject: DocumentationObject;
 }
 
-const replaceHandoffImportTokens = (content: string, components: string[], currentPath: string, rootPath: string, rootReturnPath: string) => {
+const replaceHandoffImportTokens = (
+  content: string,
+  components: string[],
+  currentPath: string,
+  rootPath: string,
+  rootReturnPath: string
+) => {
   getHandoffImportTokens(components, currentPath, rootPath, rootReturnPath).forEach(([token, imports]) => {
     content = content.replaceAll(`//<#${token}#>`, imports.map((path) => `@import '${path}';`).join(`\r\n`));
   });

--- a/src/transformers/integration/index.ts
+++ b/src/transformers/integration/index.ts
@@ -133,7 +133,9 @@ const buildIntegration = async (
   rootPath ??= sourcePath;
 
   const items = await fs.readdir(sourcePath);
+
   const components = Object.keys(documentationObject.components);
+  const componentsWithInstances = components.filter((component) => documentationObject.components[component].instances.length > 0);
 
   for (const item of items) {
     const sourceItemPath = path.join(sourcePath, item);
@@ -159,7 +161,7 @@ const buildIntegration = async (
       // Ensure the directory exists before writing the file
       await fs.ensureDir(path.dirname(destItemPath));
       // Write the rendered content to the destination path
-      await fs.writeFile(destItemPath, replaceHandoffImportTokens(renderedContent, components, path.parse(destItemPath).dir, rootPath, rootReturnPath ?? '../'));
+      await fs.writeFile(destItemPath, replaceHandoffImportTokens(renderedContent, componentsWithInstances, path.parse(destItemPath).dir, rootPath, rootReturnPath ?? '../'));
     }
   }
 };

--- a/src/utils/preview.ts
+++ b/src/utils/preview.ts
@@ -95,9 +95,11 @@ export const buildClientFiles = async (handoff: Handoff): Promise<string> => {
     const compile = webpack(config);
     compile.run((err, stats) => {
       if (err) {
-        let error = 'Errors encountered trying to build preview styles.\n';
+        let error = chalk.red('Errors encountered trying to build preview styles.') + '\n  The integration sass expects a token that isn\'t found in your Figma component.\n';
         if (handoff.debug) {
-          error += err.stack || err;
+          error += chalk.yellow('\n\n---------- Sass Build Error Trace ---------- \n') + err.stack || err;
+        }else{
+          error += 'Add the --debug flag to see the full error trace\n\n';
         }
         return reject(error);
       }
@@ -105,9 +107,11 @@ export const buildClientFiles = async (handoff: Handoff): Promise<string> => {
       if (stats) {
         if (stats.hasErrors()) {
           let buildErrors = stats.compilation.errors?.map((err) => err.message);
-          let error = 'Errors encountered trying to build preview styles.\n';
+          let error = chalk.red('Errors encountered trying to build preview styles.') + '\nThe integration sass expects a token that isn\'t found in your Figma component.\n';
           if (handoff.debug) {
-            error += buildErrors;
+            error += chalk.yellow('\n\n---------- Sass Build Error Trace ---------- \n') + buildErrors;
+          }else{
+            error += 'Add the --debug flag to see the full error trace\n\n';
           }
           return reject(error);
         }


### PR DESCRIPTION
Fix a bug where a component is published but not annotated and results in an empty component set and the integration still expects it. When this happens, an integration will include map files not appropriate to the export, and then fail. 