### PR TITLE
Fixing typing bugs in 0.15.0 release

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.15.1] - 2024-11-05
+## [0.15.1] - 2024-11-27
 This is a minor release to fix several small typing issues that cause problems 
 in the linter when running as a local NPM package.
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.1] - 2024-11-05
+This is a minor release to fix several small typing issues that cause problems 
+in the linter when running as a local NPM package.
+
+### Bugfixes
+- Fixes a typing issue in the transformers when including the handoff core package
+- Fixes a typing issue when including the ReferenceObject type
+
 ## [0.15.0] - 2024-11-05
 
 This release allows Figma foundation styles - Colors, Typography, and Effects

--- a/dist/cli.js
+++ b/dist/cli.js
@@ -38,7 +38,7 @@ var HandoffCliError = /** @class */ (function (_super) {
  * Show the help message
  */
 var showVersion = function () {
-    return 'Handoff App - 0.15.0';
+    return 'Handoff App - 0.15.1';
 };
 /**
  * Define a CLI error

--- a/dist/transformers/css/component.d.ts
+++ b/dist/transformers/css/component.d.ts
@@ -1,7 +1,7 @@
 import { ComponentInstance, FileComponentObject } from '../../exporters/components/types';
 import { IntegrationObjectComponentOptions } from '../../types/config';
 import { Token } from '../types';
-import Handoff from 'handoff/index';
+import Handoff from '../../index';
 /**
  * Map down to a variable object
  * @param alerts

--- a/dist/transformers/css/index.d.ts
+++ b/dist/transformers/css/index.d.ts
@@ -1,4 +1,4 @@
-import Handoff from 'handoff/index';
+import Handoff from '../../index';
 import { DocumentationObject } from '../../types';
 import { IntegrationObject } from '../../types/config';
 import { TransformerOutput } from '../types';

--- a/dist/transformers/scss/index.d.ts
+++ b/dist/transformers/scss/index.d.ts
@@ -1,7 +1,7 @@
 import { DocumentationObject } from '../../types';
 import { TransformerOutput } from '../types';
 import { IntegrationObject } from '../../types/config';
-import Handoff from 'handoff/index';
+import Handoff from '../../index';
 /**
  * Build a set of Component types to use as a set of SCSS vars
  * @param documentationObject

--- a/dist/transformers/sd/component.d.ts
+++ b/dist/transformers/sd/component.d.ts
@@ -1,6 +1,6 @@
 import { FileComponentObject } from '../../exporters/components/types';
 import { IntegrationObjectComponentOptions } from '../../types/config';
-import Handoff from 'handoff/index';
+import Handoff from '../../index';
 /**
  * Transforms the component tokens into a style dictionary
  * @param alerts

--- a/dist/transformers/sd/index.d.ts
+++ b/dist/transformers/sd/index.d.ts
@@ -1,4 +1,4 @@
-import Handoff from 'handoff/index';
+import Handoff from '../../index';
 import { DocumentationObject } from '../../types';
 import { IntegrationObject } from '../../types/config';
 import { TransformerOutput } from '../types';

--- a/dist/transformers/utils.d.ts
+++ b/dist/transformers/utils.d.ts
@@ -24,14 +24,20 @@ export declare const formatComponentCodeBlockComment: (component: ComponentInsta
  * @param options
  * @returns
  */
-export declare const formatTokenName: (tokenType: TokenType, componentName: string, componentVariantProps: [string, string][], part: string, property: string, options?: IntegrationObjectComponentOptions) => string;
+export declare const formatTokenName: (tokenType: TokenType, componentName: string, componentVariantProps: [
+    string,
+    string
+][], part: string, property: string, options?: IntegrationObjectComponentOptions) => string;
 /**
  * Returns the token name segments
  * @param component
  * @param options
  * @returns
  */
-export declare const getTokenNameSegments: (componentName: string, componentVariantProps: [string, string][], part: string, property: string, options?: IntegrationObjectComponentOptions) => string[];
+export declare const getTokenNameSegments: (componentName: string, componentVariantProps: [
+    string,
+    string
+][], part: string, property: string, options?: IntegrationObjectComponentOptions) => string[];
 /**
  * Normalizes the token name variable (specifier) by considering if the value should be replaced
  * with some other value based replace rules defined in the transformer options of the component

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,7 +19,7 @@ class HandoffCliError extends Error {
  * Show the help message
  */
 const showVersion = () => {
-  return 'Handoff App - 0.15.0';
+  return 'Handoff App - 0.15.1';
 };
 
 /**

--- a/src/transformers/css/component.ts
+++ b/src/transformers/css/component.ts
@@ -3,7 +3,7 @@ import { formatComponentCodeBlockComment } from '../utils';
 import { transform } from '../transformer';
 import { IntegrationObjectComponentOptions } from '../../types/config';
 import { Token } from '../types';
-import Handoff from 'handoff/index';
+import Handoff from '../../index';
 import { toMachineName, toSDMachineName } from '../../exporters/design';
 
 /**

--- a/src/transformers/css/index.ts
+++ b/src/transformers/css/index.ts
@@ -1,4 +1,4 @@
-import Handoff from 'handoff/index';
+import Handoff from '../../index';
 import { DocumentationObject } from '../../types';
 import { IntegrationObject } from '../../types/config';
 import { TransformerOutput } from '../types';

--- a/src/transformers/scss/index.ts
+++ b/src/transformers/scss/index.ts
@@ -7,7 +7,7 @@ import { formatComponentCodeBlockComment } from '../utils';
 import { TransformerOutput } from '../types';
 import { IntegrationObject } from '../../types/config';
 import { tokenReferenceFormat } from '../css/component';
-import Handoff from 'handoff/index';
+import Handoff from '../../index';
 
 /**
  * Build a set of Component types to use as a set of SCSS vars

--- a/src/transformers/sd/component.ts
+++ b/src/transformers/sd/component.ts
@@ -2,7 +2,7 @@ import { transform } from '../transformer';
 import { FileComponentObject } from '../../exporters/components/types';
 import { IntegrationObjectComponentOptions } from '../../types/config';
 import { tokenReferenceFormat } from '../css/component';
-import Handoff from 'handoff/index';
+import Handoff from '../../index';
 
 /**
  * Transforms the component tokens into a style dictionary

--- a/src/transformers/sd/index.ts
+++ b/src/transformers/sd/index.ts
@@ -1,4 +1,4 @@
-import Handoff from 'handoff/index';
+import Handoff from '../../index';
 import { DocumentationObject } from '../../types';
 import { IntegrationObject } from '../../types/config';
 import { TransformerOutput } from '../types';

--- a/src/transformers/transformer.ts
+++ b/src/transformers/transformer.ts
@@ -3,7 +3,7 @@ import { Token, TokenDict, TokenType } from './types';
 import { formatTokenName, getTokenNameSegments } from './utils';
 import { getTokenSetTokens } from './tokens';
 import { IntegrationObjectComponentOptions } from '../types/config';
-import { ReferenceObject } from 'handoff/types';
+import { ReferenceObject } from '../types';
 
 /**
  * Performs the transformation of the component tokens.


### PR DESCRIPTION
## [0.15.1] - 2024-11-26
This is a minor release to fix several small typing issues that cause problems 
in the linter when running as a local NPM package.

### Bugfixes
- Fixes a typing issue in the transformers when including the handoff core package
- Fixes a typing issue when including the ReferenceObject type