### PR TITLE
Release/0.15.2

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.2] - 2024-12-11
+This release fixes a small bug when pulling foundation tokens with nested names.
+
+### Bugfixes
+- Figma's name schema delivers names as {group}/{name}. If your foundation 
+(color, shadow, etc) names include a slash `Blue/100` Handoff would only grab
+the first part of that name, and construct the token excluding the remaining
+data. This patch resolves that so instead of getting `primitive-blue` you will
+now get `primitive-blue-100` as your token.
+
 ## [0.15.1] - 2024-11-27
 This is a minor release to fix several small typing issues that cause problems 
 in the linter when running as a local NPM package.

--- a/dist/cli.js
+++ b/dist/cli.js
@@ -38,7 +38,7 @@ var HandoffCliError = /** @class */ (function (_super) {
  * Show the help message
  */
 var showVersion = function () {
-    return 'Handoff App - 0.15.1';
+    return 'Handoff App - 0.15.2';
 };
 /**
  * Define a CLI error

--- a/dist/exporters/design.js
+++ b/dist/exporters/design.js
@@ -87,6 +87,7 @@ exports.toSDMachineName = toSDMachineName;
  * @returns GroupNameData
  */
 var fieldData = function (name) {
+    console.log(name);
     var nameArray = name.split('/');
     var data = {
         name: '',
@@ -95,7 +96,7 @@ var fieldData = function (name) {
     };
     if (nameArray[1]) {
         data.group = (0, exports.toMachineName)(nameArray[0]);
-        data.name = nameArray[1];
+        data.name = nameArray.splice(1).join(' ');
         data.machine_name = (0, exports.toMachineName)(data.name);
     }
     else {

--- a/dist/exporters/design.js
+++ b/dist/exporters/design.js
@@ -87,7 +87,6 @@ exports.toSDMachineName = toSDMachineName;
  * @returns GroupNameData
  */
 var fieldData = function (name) {
-    console.log(name);
     var nameArray = name.split('/');
     var data = {
         name: '',

--- a/dist/transformers/utils.d.ts
+++ b/dist/transformers/utils.d.ts
@@ -24,14 +24,20 @@ export declare const formatComponentCodeBlockComment: (component: ComponentInsta
  * @param options
  * @returns
  */
-export declare const formatTokenName: (tokenType: TokenType, componentName: string, componentVariantProps: [string, string][], part: string, property: string, options?: IntegrationObjectComponentOptions) => string;
+export declare const formatTokenName: (tokenType: TokenType, componentName: string, componentVariantProps: [
+    string,
+    string
+][], part: string, property: string, options?: IntegrationObjectComponentOptions) => string;
 /**
  * Returns the token name segments
  * @param component
  * @param options
  * @returns
  */
-export declare const getTokenNameSegments: (componentName: string, componentVariantProps: [string, string][], part: string, property: string, options?: IntegrationObjectComponentOptions) => string[];
+export declare const getTokenNameSegments: (componentName: string, componentVariantProps: [
+    string,
+    string
+][], part: string, property: string, options?: IntegrationObjectComponentOptions) => string[];
 /**
  * Normalizes the token name variable (specifier) by considering if the value should be replaced
  * with some other value based replace rules defined in the transformer options of the component

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,7 +19,7 @@ class HandoffCliError extends Error {
  * Show the help message
  */
 const showVersion = () => {
-  return 'Handoff App - 0.15.1';
+  return 'Handoff App - 0.15.2';
 };
 
 /**

--- a/src/exporters/design.ts
+++ b/src/exporters/design.ts
@@ -42,7 +42,6 @@ export const toSDMachineName = (name: string): string => {
  * @returns GroupNameData
  */
 const fieldData = (name: string): GroupNameData => {
-  console.log(name);
   let nameArray = name.split('/');
   const data = {
     name: '',

--- a/src/exporters/design.ts
+++ b/src/exporters/design.ts
@@ -42,6 +42,7 @@ export const toSDMachineName = (name: string): string => {
  * @returns GroupNameData
  */
 const fieldData = (name: string): GroupNameData => {
+  console.log(name);
   let nameArray = name.split('/');
   const data = {
     name: '',
@@ -50,7 +51,7 @@ const fieldData = (name: string): GroupNameData => {
   };
   if (nameArray[1]) {
     data.group = toMachineName(nameArray[0]!);
-    data.name = nameArray[1];
+    data.name = nameArray.splice(1).join(' ');
     data.machine_name = toMachineName(data.name);
   } else {
     data.name = nameArray[0]!;


### PR DESCRIPTION
This release fixes a problem with token naming if there is a nested token.  It does it by grabbing everything after the first slash and generating a name with all of that, to use for the machine name.

# Release Notes

## [0.15.2] - 2024-12-11
This release fixes a small bug when pulling foundation tokens with nested names.

### Bugfixes
- Figma's name schema delivers names as {group}/{name}. If your foundation (color, shadow, etc) names include a slash `Blue/100` Handoff would only grab the first part of that name, and construct the token excluding the remaining data. This patch resolves that so instead of getting `primitive-blue` you will now get `primitive-blue-100` as your token.