### PR TITLE
Increasing flexibility of slot defaults

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,11 @@ This patch release clears ESLint failures in the Next.js app pages and aligns
 several code paths with the compiler target so production builds succeed without
 enabling `--downlevelIteration`.
 
+### Change
+
+* Altered the avaliable types to the SlotMetadata so the default can handle
+  a wide variaty of types - `default?: string | number | boolean | object | any[] | null;`
+
 ### Lint and code quality
 
 * Resolved `no-else-return`, `no-unused-vars`, `camelcase`, `prefer-const`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "handoff-app",
-  "version": "1.2.2-4",
+  "version": "1.2.2-5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "handoff-app",
-      "version": "1.2.2-4",
+      "version": "1.2.2-5",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^0.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "handoff-app",
-  "version": "1.2.2-4",
+  "version": "1.2.2-5",
   "description": "Automated documentation toolchain for building client side documentation from figma",
   "author ": {
     "name": "Convertiv",

--- a/src/transformers/preview/component.ts
+++ b/src/transformers/preview/component.ts
@@ -2,10 +2,10 @@ import type { DocAnnotation, TypeNode } from 'handoff-docgen';
 import path from 'path';
 import Handoff from '../../index';
 import { getAPIPath } from './component/api';
-import writeComponentSummaryAPI from './component/summary';
 import processComponents from './component/builder';
 import { buildMainCss } from './component/css';
 import { buildMainJS } from './component/javascript';
+import writeComponentSummaryAPI from './component/summary';
 
 export interface ComponentMetadata {
   title: string;
@@ -33,7 +33,7 @@ export interface SlotMetadata {
   name: string;
   description: string;
   generic: string;
-  default?: string;
+  default?: string | number | boolean | object | any[] | null;
   type: SlotType;
   // used if type is array
   items?: {


### PR DESCRIPTION
Working with the new ts components, and I often need to declare different defaults.  The string and undefined is too restrictive to handle all the cases I have